### PR TITLE
Fix broken const evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chromaterm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Yet another crate for terminal colors."

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ impl ColorSupport {
         value << Self::BIT_SHIFT
     }
 
-    const fn from_config(config: u8) -> Self {
+    fn from_config(config: u8) -> Self {
         const MASK: u8 = 0b11_000000;
         match (config & MASK) >> Self::BIT_SHIFT {
             0b00 => Self::None,
@@ -56,7 +56,7 @@ impl Fallback {
         value << Self::BIT_SHIFT
     }
 
-    const fn from_config(config: u8) -> Self {
+    fn from_config(config: u8) -> Self {
         const MASK: u8 = 0b00_1_00000;
         match (config & MASK) >> Self::BIT_SHIFT {
             0 => Self::No,


### PR DESCRIPTION
An `unreachable!` panic was marked as non-const.
