### PR TITLE
Update rstest dev-dependency to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ rust-version = "1.85.1"
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
-rstest = { version = "0.25", default-features = false, features = ["crate-name"] }
+rstest = { version = "0.26", default-features = false, features = ["crate-name"] }


### PR DESCRIPTION
Nothing special here, just bumping the dependency downstream in Fedora’s [`rust-chromaterm` package](https://src.fedoraproject.org/rpms/rust-chromaterm) and sending the corresponding change upstream.

Nothing in https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md looks like it should affect this crate, and `cargo test` still passes.